### PR TITLE
Swap out JSON::XS for JSON::MaybeXS

### DIFF
--- a/t/10-presidential-data.t
+++ b/t/10-presidential-data.t
@@ -6,7 +6,7 @@ use Test::Most;
 use TestSettings;
 use String::Random;
 use Data::Dumper;
-use JSON::XS;
+use JSON::MaybeXS qw(decode_json);
 
 
 unless ( $ENV{'AMAZON_DYNAMODB_EXPENSIVE_TESTS'} ) {
@@ -33,7 +33,7 @@ my $presidents_data;
 }
 close($fh);
 
-$presidents_data = JSON::XS::decode_json($presidents_data);
+$presidents_data = decode_json($presidents_data);
 ok(defined($presidents_data), "presidents.json was successfully read");
 
 


### PR DESCRIPTION
This allows the user to select between JSON backends, for example having Cpanel::JSON::XS installed instead of JSON::XS, or not having any XS support available at all.

`decode_json($result);` works the same as `JSON::XS->new->utf8->decode($result);`.