### PR TITLE
Improve error handling when using Mojo::UserAgent

### DIFF
--- a/lib/Amazon/DynamoDB/20120810.pm
+++ b/lib/Amazon/DynamoDB/20120810.pm
@@ -1067,12 +1067,15 @@ method _process_request(HTTP::Request $req, CodeRef $done?) {
                 fail => sub {
                     my ($status, $resp, $req)= @_;
                     my $r;
-                    if (defined($resp)) {
+                    if (defined($resp) && defined($resp->code)) {
                         if ($resp->code == 500) {
                             $do_retry = 1;
                             $current_retry++;
                         } elsif ($resp->code == 400) {
-                            $r = decode_json($resp->decoded_content);
+                            my $json = $resp->can('decoded_content');
+                                ? $resp->decoded_content
+                                : $resp->body; # Mojo
+                            $r = decode_json($json);
                             if ($r->{__type} =~ /ProvisionedThroughputExceededException$/) {
                                 # Need to sleep
                                 $do_retry = 1;

--- a/lib/Amazon/DynamoDB/MojoUA.pm
+++ b/lib/Amazon/DynamoDB/MojoUA.pm
@@ -38,13 +38,13 @@ sub request {
 	my $self = shift;
 	my $req = shift;
 	my $method = lc $req->method;
-	my $resp = $self->ua->$method(''.$req->uri => { map {; $_ => ''.$req->header($_) } $req->header_field_names } => $req->content);
-	if(my $res = $resp->success) {
+	my $tx = $self->ua->$method(''.$req->uri => { map {; $_ => ''.$req->header($_) } $req->header_field_names } => $req->content);
+	if(my $res = $tx->success) {
 		return Future->new->done($res->body)
 	}
 
-	my $status = join ' ', $resp->error;
-	return Future->new->fail($status, $resp, $req)
+	my $status = $tx->res->code;
+	return Future->new->fail($status, $tx->res, $req)
 }
 
 =head2 ua


### PR DESCRIPTION
@rustyconover thanks for writing this module.  I was able to get up and running pretty quickly.

Error handling with Mojo:UserAgent has some issues.  `Mojo::UserAgent->request()` doesn't return a `$response` object.  It returns a `$tx` transaction object.  A "transaction" contains both the response and the request via `$tx->response()` and `$tx->request()`.

This pr makes errors behave in the same pretty way they normally do when using NaHTTP instead of dying in the middle of `_process_request()`.

Thanks!